### PR TITLE
Fix bug circle appear after clear board or undo move

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,8 +7,6 @@ This is a board which you can:
 - change color of next placing pieces (press button 1)
 - change the changing color mode (keep old color as the color for next pieces or change the color sequentially - by press space bar)
 - undo placing pieces (press button j)
-- clear the board (by press button 3*)
+- clear the board (by press button 3)
 
 But first you must focus (click) on the board to make these button pressing take effect (currently I don't know how to auto focus on the canvas when the page finish loading :()
-
-(* there still an error here: when you place some pieces and clear the board, there is an circle still appear in the board. I don't know how to fix this bug, if you know please tell me, thank you very much :D)

--- a/go.js
+++ b/go.js
@@ -8,20 +8,22 @@ var canvas = document.getElementById("go_board");
 var context = canvas.getContext("2d");
 
 function drawBoardLines(ctx) {
-  var i, drawPoint, drawLength;
+  var i, drawPointX, drawPointY, drawLength;
   drawLength = (numLines - 1) * interval + topLeftX;
 
   for (i = 0; i < numLines; i++) {
-    drawPoint = topLeftX + i * interval;
-    ctx.moveTo(drawPoint, topLeftY);
-    ctx.lineTo(drawPoint, drawLength);
+    drawPointX = topLeftX + i * interval;
+    ctx.beginPath();
+    ctx.moveTo(drawPointX, topLeftY);
+    ctx.lineTo(drawPointX, drawLength);
+    ctx.closePath();
     ctx.stroke();
-  }
 
-  for (i = 0; i < numLines; i++) {
-    drawPoint = topLeftY + i * interval;
-    ctx.moveTo(topLeftX, drawPoint);
-    ctx.lineTo(drawLength, drawPoint);
+    drawPointY = topLeftY + i * interval;
+    ctx.beginPath();
+    ctx.moveTo(topLeftX, drawPointY);
+    ctx.lineTo(drawLength, drawPointY);
+    ctx.closePath();
     ctx.stroke();
   }
 }


### PR DESCRIPTION
We must use beginPath() and closePath() before and after create line to remove previous path entries
